### PR TITLE
DFS 복습

### DIFF
--- a/src/backjoon/solution/P11724_2.java
+++ b/src/backjoon/solution/P11724_2.java
@@ -1,0 +1,58 @@
+package backjoon.solution;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class P11724_2 {
+	static ArrayList<Integer>[] A;
+	static boolean visited[];
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		int n = Integer.parseInt(st.nextToken());
+		int m = Integer.parseInt(st.nextToken());
+		
+		A = new ArrayList[n+1];
+		visited = new boolean[n+1];
+		
+		for(int i=1; i<n+1; i++) {
+			A[i] = new ArrayList<Integer>();
+		}
+		
+		for(int i=0; i<m; i++) {
+			st = new StringTokenizer(br.readLine());
+			int s = Integer.parseInt(st.nextToken());
+			int e = Integer.parseInt(st.nextToken());
+			A[s].add(e);
+			A[e].add(s);
+		}
+		
+		int count = 0;
+		for(int i=1; i<n+1; i++) {
+			if(!visited[i]) {
+				count++;
+				DFS(i);
+			}
+		}
+		
+		System.out.println(count);
+	}
+	
+	static void DFS(int v) {
+		if(visited[v]) {
+			return;
+		}
+		
+		visited[v] = true;
+		for(int i : A[v]) {
+			if(visited[i] == false) {
+				DFS(i);
+			}
+		}
+	}
+}


### PR DESCRIPTION
깊이 우선 탐색(DFS)
 - 그래프 완전 탐색 기법 중 하나
 - 시작 노드에서 시작하여 탐색할 한쪽 분기를 정하여 최대 깊이까지 탐색을 마친 후 다른 쪽 분기로 이동하여 다시 탐색을 수행하는 알고리즘
 - 한번 방문한 노드는 다시 방문해선 안된다
